### PR TITLE
Decrease the default value of historian-history-length

### DIFF
--- a/historian.el
+++ b/historian.el
@@ -39,7 +39,7 @@
 
 (defvar historian-save-file (locate-user-emacs-file ".historian"))
 
-(defcustom historian-history-length 5000
+(defcustom historian-history-length 10
   "Determines how many recently selected candidates Historian should remember."
   :type 'number
   :group 'historian)


### PR DESCRIPTION
Large `.historian` files equal slow Emacs startup and shutdown. `smex`
only remembers the last 7 items, so 5000 seems a little excessive.