### PR TITLE
Suppress byte-compile warnings

### DIFF
--- a/historian-ivy.el
+++ b/historian-ivy.el
@@ -74,8 +74,8 @@
   (if (not historian-mode)
       (funcall old-fun name cands)
     (cl-letf*
-        ((old-flx-score (symbol-function #'flx-score))
-         ((symbol-function #'flx-score)
+        ((old-flx-score (symbol-function 'flx-score))
+         ((symbol-function 'flx-score)
           (lambda (str query &optional cache)
             (let* ((orig-score
                     (funcall old-flx-score str query cache))

--- a/historian.el
+++ b/historian.el
@@ -122,7 +122,7 @@
                     #'historian--nadvice/completing-read)
 
         (when (and historian-enable-helm
-                   (fboundp #'helm-comp-read))
+                   (fboundp 'helm-comp-read))
           (advice-add 'helm-comp-read :around
                       #'historian--nadvice/helm-comp-read))
 


### PR DESCRIPTION
```
historian.el:141:1:Warning: the function ‘helm-comp-read’ is not known to be
    defined.

historian-ivy.el:130:1:Warning: the function ‘flx-score’ is not known to be
    defined.
```

Because byte-compiler assumes `#'some-func` is defined before using it.