### PR TITLE
no pretty-printing, (featurep 'hashtable-print-readable) much faster

### DIFF
--- a/historian.el
+++ b/historian.el
@@ -86,16 +86,16 @@
 (defun historian-save ()
   (interactive)
   (with-temp-file historian-save-file
-    (insert (pp historian--history-table))))
+    (prin1 historian--history-table (current-buffer))))
 
 ;;;###autoload
 (defun historian-load ()
   (interactive)
   (setq historian--history-table
         (if (file-exists-p historian-save-file)
-            (car (read-from-string (with-temp-buffer
-                                     (insert-file-contents historian-save-file)
-                                     (buffer-string))))
+            (with-temp-buffer
+              (insert-file-contents historian-save-file)
+              (read (current-buffer)))
           (make-hash-table))))
 
 ;;;###autoload


### PR DESCRIPTION
since we already require 24.4

(history-save was taking like 20 seconds each time!)