### PR TITLE
prevent abbreviating history table while save

### DIFF
--- a/historian.el
+++ b/historian.el
@@ -86,7 +86,9 @@
 (defun historian-save ()
   (interactive)
   (with-temp-file historian-save-file
-    (prin1 historian--history-table (current-buffer))))
+    (let ((print-length nil)
+          (print-level nil))
+      (prin1 historian--history-table (current-buffer)))))
 
 ;;;###autoload
 (defun historian-load ()


### PR DESCRIPTION
I wrote about this in #8 